### PR TITLE
Add unistd.h for chdir on linux

### DIFF
--- a/src/nesl.cpp
+++ b/src/nesl.cpp
@@ -5,6 +5,7 @@
     #include <direct.h>
 #else
     #include <sys/stat.h>
+    #include <unistd.h>
 #endif
 #include <bitset>
 #include <signal.h>


### PR DESCRIPTION
nesl.cpp calls `chdir(...)` but does not include the POSIX header that declares it on Linux.